### PR TITLE
Fix 4khdhub

### DIFF
--- a/src/extractor/ExtractorRegistry.ts
+++ b/src/extractor/ExtractorRegistry.ts
@@ -46,6 +46,20 @@ export class ExtractorRegistry {
     const normalizedUrl = extractor.normalize(url);
     const cacheKey = this.determineCacheKey(ctx, extractor, normalizedUrl);
 
+    if (allowLazy && meta?.sourceId === '4khdhub' && ['hubcloud', 'hubdrive'].includes(extractor.id)) {
+      const extractUrl = new URL('/extract/', ctx.hostUrl);
+      extractUrl.searchParams.set('index', '0');
+      extractUrl.searchParams.set('url', normalizedUrl.href);
+
+      return [{
+        url: extractUrl,
+        format: Format.unknown,
+        label: extractor.label,
+        ttl: extractor.ttl,
+        meta: { extractorId: extractor.id, ...meta },
+      }];
+    }
+
     const storedDataRaw = await this.urlResultCache.getRaw<UrlResult[]>(cacheKey);
     const expires = storedDataRaw?.expires;
     if (storedDataRaw && expires) {

--- a/src/source/FourKHDHub.ts
+++ b/src/source/FourKHDHub.ts
@@ -23,6 +23,7 @@ export class FourKHDHub extends Source {
   private readonly DOMAIN_KEY = '4khdhub';
 
   private readonly FALLBACK_CANDIDATES = [
+    'https://4khdhub.link',
     'https://4khdhub.click',
     'https://4khdhub.ink',
     'https://4khdhub.one',


### PR DESCRIPTION
- Add 4khdhub.link to the 4KHDHub fallback domain list
- Return lazy extract URLs for 4KHDHub HubCloud/HubDrive links so stream results are not dropped during pre-extraction